### PR TITLE
adds underscore dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "dependencies": {
     "node-uuid": "1.4.7",
-    "pg": "4.4.3"
+    "pg": "4.4.3",
+    "underscore": "1.8.3"
   },
   "devDependencies": {
     "seneca": "plugin",


### PR DESCRIPTION
Hi @mirceaalexandru Trying to upgrade to 1.1.0 as per your https://github.com/CoderDojo/community-platform/issues/831#issuecomment-164456907 but crashing on an underscore dependency.

Also, is there any difference between [seneca-postgreSQL-store](https://www.npmjs.com/package/seneca-postgresql-store) and [seneca-POSTGRES-store](https://www.npmjs.com/package/seneca-postgres-store)?
I am loading the dependency from my fork for now, and had to change the require statement cause of the different name in the repo.